### PR TITLE
Set Guild House as rested area

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ All guilds will get their own phasing system and then the guild master can purch
 * Class Trainers (all available in Wrath)
 * Primary Profession Trainers (all available in Wrath)
 * Secondary Profession Trainers (all available in Wrath)
-* Vendors: Reagents Vendor, Food & Water, Trade Goods, and Repairs/Ammo Vendor
+* Vendors: Reagents Vendor, Food & Drink, Trade Goods, Ammo & Repair Vendor, and Poisons Vendor
 * Portals to Neutral, Horde and Alliance cities
 * Spirit Healer
 * Guild Bank and Personal Bank access
-* Auctioneer
+* Auctioneer/Neutral Auctioneer
 * Stable Master
 
 ## How to use ingame
@@ -42,7 +42,7 @@ All guilds will get their own phasing system and then the guild master can purch
 
 ## Edit module configuration (optional)
 
-If you need to change the module configuration, go to your server configuration folder (where your `worldserver` or `worldserver.exe` is), copy `mod_guild_house_v2.conf.dist` to `mod_guild_house_v2.conf` and edit that new file.
+If you need to change the module configuration, go to your server configuration folder (where your `worldserver` or `worldserver.exe` is), copy `mod_guildhouse.conf.dist` to `mod_guildhouse.conf` and edit that new file.
 
 ## Credits
 

--- a/src/mod_guildhouse.cpp
+++ b/src/mod_guildhouse.cpp
@@ -528,8 +528,6 @@ public:
 	{
         if (player->GetZoneId() == 876 && player->GetAreaId() == 876) // GM Island
 		{
-            ChatHandler(player->GetSession()).PSendSysMessage("Removing rested state...");  // Testing
-			
 			// Remove the rested state when teleporting from the guild house
 			player->RemoveRestState();
 		}

--- a/src/mod_guildhouse.cpp
+++ b/src/mod_guildhouse.cpp
@@ -524,6 +524,17 @@ public:
             player->SetPhaseMask(GetNormalPhase(player), true);
     }
 
+    void OnBeforeTeleport(Player *player, uint32 mapid, float x, float y, float z, float orientation, uint32 options, Unit *target)
+	{
+        if (player->GetZoneId() == 876 && player->GetAreaId() == 876) // GM Island
+		{
+            ChatHandler(player->GetSession()).PSendSysMessage("Removing rested state...");  // Testing
+			
+			// Remove the rested state when teleporting from the guild house
+			player->RemoveRestState();
+		}
+	}
+	
     uint32 GetNormalPhase(Player *player) const
     {
         if (player->IsGameMaster())
@@ -562,7 +573,7 @@ public:
         if (player->GetZoneId() == 876 && player->GetAreaId() == 876) // GM Island
         {
 			// Set the guild house as a rested area
-			player->SetPlayerFlag(PLAYER_FLAGS_RESTING);
+			player->SetRestState(0);
 			
             // If player is not in a guild he doesnt have a guild house teleport away
             // TODO: What if they are in a guild, but somehow are in the wrong phaseMask and seeing someone else's area?

--- a/src/mod_guildhouse.cpp
+++ b/src/mod_guildhouse.cpp
@@ -526,6 +526,14 @@ public:
 
     bool OnBeforeTeleport(Player *player, uint32 mapid, float x, float y, float z, float orientation, uint32 options, Unit *target)
 	{
+		(void)mapid;
+		(void)x;
+		(void)y;
+		(void)z;
+		(void)orientation;
+		(void)options;
+		(void)target;
+
         if (player->GetZoneId() == 876 && player->GetAreaId() == 876) // GM Island
 		{
 			// Remove the rested state when teleporting from the guild house

--- a/src/mod_guildhouse.cpp
+++ b/src/mod_guildhouse.cpp
@@ -562,7 +562,7 @@ public:
         if (player->GetZoneId() == 876 && player->GetAreaId() == 876) // GM Island
         {
 			// Set the guild house as a rested area
-			SetPlayerFlag(PLAYER_FLAGS_RESTING);
+			player->SetPlayerFlag(PLAYER_FLAGS_RESTING);
 			
             // If player is not in a guild he doesnt have a guild house teleport away
             // TODO: What if they are in a guild, but somehow are in the wrong phaseMask and seeing someone else's area?

--- a/src/mod_guildhouse.cpp
+++ b/src/mod_guildhouse.cpp
@@ -524,7 +524,7 @@ public:
             player->SetPhaseMask(GetNormalPhase(player), true);
     }
 
-    void OnBeforeTeleport(Player *player, uint32 mapid, float x, float y, float z, float orientation, uint32 options, Unit *target)
+    bool OnBeforeTeleport(Player *player, uint32 mapid, float x, float y, float z, float orientation, uint32 options, Unit *target)
 	{
         if (player->GetZoneId() == 876 && player->GetAreaId() == 876) // GM Island
 		{
@@ -533,8 +533,10 @@ public:
 			// Remove the rested state when teleporting from the guild house
 			player->RemoveRestState();
 		}
+		
+		return true;
 	}
-	
+
     uint32 GetNormalPhase(Player *player) const
     {
         if (player->IsGameMaster())

--- a/src/mod_guildhouse.cpp
+++ b/src/mod_guildhouse.cpp
@@ -561,6 +561,9 @@ public:
 
         if (player->GetZoneId() == 876 && player->GetAreaId() == 876) // GM Island
         {
+			// Set the guild house as a rested area
+			SetPlayerFlag(PLAYER_FLAGS_RESTING);
+			
             // If player is not in a guild he doesnt have a guild house teleport away
             // TODO: What if they are in a guild, but somehow are in the wrong phaseMask and seeing someone else's area?
 


### PR DESCRIPTION
I've updated so that when teleporting to the guild house the player is set to have the rested flag.  The only catch I've noticed so far is that when you log out and back in the flag is set properly by the code, but something else in the core seems to unset that flag (no idea where).  Once you move of course it is set again.

I'd be happy to update to handle the login better with some help.