### PR TITLE
Make IDs easier to edit

### DIFF
--- a/sql/world/guildhouse_spawns.sql
+++ b/sql/world/guildhouse_spawns.sql
@@ -10,6 +10,10 @@ CREATE TABLE IF NOT EXISTS `guild_house_spawns` (
   UNIQUE KEY `entry` (`entry`)
 ) ENGINE=InnoDB AUTO_INCREMENT=51 DEFAULT CHARSET=utf8;
 
+-- !!! NOTE: set these before running the queries in order to avoid conflicts !!!
+SET @C_TEMPLATE = 500030;
+SET @GO_TEMPLATE = 500000;
+
 REPLACE INTO `guild_house_spawns` (`id`, `entry`, `posX`, `posY`, `posZ`, `orientation`, `comment`) VALUES
 	(1, 26327, 16216.5, 16279.4, 20.9306, 0.552869, 'Paladin Trainer'),
 	(2, 26324, 16221.3, 16275.7, 20.9285, 1.37363, 'Druid Trainer'),
@@ -20,7 +24,7 @@ REPLACE INTO `guild_house_spawns` (`id`, `entry`, `posX`, `posY`, `posZ`, `orien
 	(7, 26330, 16235.5, 16280.8, 20.9257, 2.18652, 'Shaman Trainer'),
 	(8, 26331, 16240.8, 16283.3, 20.9299, 1.86843, 'Warlock Trainer'),
 	(9, 26332, 16246.6, 16284.5, 20.9301, 1.68975, 'Warrior Trainer'),
-	(10, 500032, 16218.9, 16284.5, 13.1761, 6.18533, 'Innkeeper'),
+	(10, @C_TEMPLATE + 2, 16218.9, 16284.5, 13.1761, 6.18533, 'Innkeeper'),
 	(11, 30605, 16228.0, 16280.5, 13.1761, 2.98877, 'Banker'),
 	(12, 29195, 16252.3, 16284.9, 20.9324, 1.79537, 'Death Knight Trainer'),
 	(13, 2836, 16220.5, 16302.3, 13.176, 6.14647, 'Blacksmithing Trainer'),
@@ -45,16 +49,16 @@ REPLACE INTO `guild_house_spawns` (`id`, `entry`, `posX`, `posY`, `posZ`, `orien
 	(32, 184137, 16220.3, 16272, 12.9736, 4.45592, 'Mailbox (Object)'),
 	(33, 1685, 16253.8, 16294.3, 13.1758, 6.11938, 'Forge (Object)'),
 	(34, 4087, 16254.4, 16298.7, 13.1758, 3.36027, 'Anvil (Object)'),
-	(35, 500000, 16232.9, 16264.1, 13.55570, 3.028813, 'Portal: Stormwind (Object)'),
-	(36, 500001, 16232.8, 16257.1, 13.93456, 3.028813, 'Portal: Darnassus (Object)'),
-	(37, 500002, 16231.3, 16254.2, 13.65647, 3.028813, 'Portal: Exodar (Object)'),
-	(38, 500003, 16233.4, 16260.6, 13.84770, 3.028813, 'Portal: Ironforge (Object)'),
-	(39, 500004, 16232.9, 16264.1, 13.55570, 3.028813, 'Portal: Orgrimmar (Object)'),
-	(40, 500005, 16231.3, 16254.2, 13.65647, 3.028813, 'Portal: Silvermoon (Object)'),
-	(41, 500006, 16233.4, 16260.6, 13.84770, 3.028813, 'Portal: Thunder Bluff (Object)'),
-	(42, 500007, 16232.8, 16257.1, 13.93456, 3.028813, 'Portal: Undercity (Object)'),
-    (43, 500008, 16211.1, 16266.9, 13.7458, 5.6724, 'Portal: Shattrath (Object)'),
-	(44, 500009, 16213.9, 16270.5, 13.1378, 5.4996, 'Portal: Dalaran (Object)'),
+	(35, @GO_TEMPLATE + 0, 16232.9, 16264.1, 13.55570, 3.028813, 'Portal: Stormwind (Object)'),
+	(36, @GO_TEMPLATE + 1, 16232.8, 16257.1, 13.93456, 3.028813, 'Portal: Darnassus (Object)'),
+	(37, @GO_TEMPLATE + 2, 16231.3, 16254.2, 13.65647, 3.028813, 'Portal: Exodar (Object)'),
+	(38, @GO_TEMPLATE + 3, 16233.4, 16260.6, 13.84770, 3.028813, 'Portal: Ironforge (Object)'),
+	(39, @GO_TEMPLATE + 4, 16232.9, 16264.1, 13.55570, 3.028813, 'Portal: Orgrimmar (Object)'),
+	(40, @GO_TEMPLATE + 5, 16231.3, 16254.2, 13.65647, 3.028813, 'Portal: Silvermoon (Object)'),
+	(41, @GO_TEMPLATE + 6, 16233.4, 16260.6, 13.84770, 3.028813, 'Portal: Thunder Bluff (Object)'),
+	(42, @GO_TEMPLATE + 7, 16232.8, 16257.1, 13.93456, 3.028813, 'Portal: Undercity (Object)'),
+    (43, @GO_TEMPLATE + 8, 16211.1, 16266.9, 13.7458, 5.6724, 'Portal: Shattrath (Object)'),
+	(44, @GO_TEMPLATE + 9, 16213.9, 16270.5, 13.1378, 5.4996, 'Portal: Dalaran (Object)'),
 	(45, 187293, 16230.5, 16283.5, 13.9061, 3, 'Guild Vault (Object)'),
 	(46, 28692, 16236.2, 16315.7, 20.8454, 4.64365, 'Trade Supplies'),
 	(47, 28776, 16223.7, 16297.9, 20.8454, 6.17044, 'Tabard Vendor'),

--- a/src/guildhouse.h
+++ b/src/guildhouse.h
@@ -1,0 +1,9 @@
+
+// Offsets from creatures_objects.sql
+constexpr uint32 GetCreatureEntry(uint32 offset) {
+    return 500150 + offset;
+}
+
+constexpr uint32 GetGameObjectEntry(uint32 offset) {
+    return 500000 + offset;
+}

--- a/src/mod_guildhouse.cpp
+++ b/src/mod_guildhouse.cpp
@@ -14,6 +14,7 @@
 #include "GameObject.h"
 #include "Transport.h"
 #include "Maps/MapMgr.h"
+#include "guildhouse.h"
 
 class GuildData : public DataMap::Base
 {
@@ -333,12 +334,12 @@ public:
         if (player->GetTeamId() == TEAM_ALLIANCE)
         {
             // Portal to Stormwind
-            entry = 500000;
+            entry = GetGameObjectEntry(0);
         }
         else
         {
             // Portal to Orgrimmar
-            entry = 500004;
+            entry = GetGameObjectEntry(4);
         }
 
         if (entry == 0)
@@ -418,7 +419,7 @@ public:
 
     void SpawnButlerNPC(Player *player)
     {
-        uint32 entry = 500031;
+        uint32 entry = GetCreatureEntry(1);
         float posX = 16202.185547f;
         float posY = 16255.916992f;
         float posZ = 21.160221f;
@@ -653,7 +654,7 @@ public:
             return false;
         }
 
-        if (player->FindNearestCreature(500031, VISIBLE_RANGE, true))
+        if (player->FindNearestCreature(GetCreatureEntry(1), VISIBLE_RANGE, true))
         {
             handler->SendSysMessage("You already have the Guild House Butler!");
             handler->SetSentErrorMessage(true);
@@ -666,7 +667,7 @@ public:
         float ori = 6.195375f;
 
         Creature *creature = new Creature();
-        if (!creature->Create(map->GenerateLowGuid<HighGuid::Unit>(), map, GetGuildPhase(player), 500031, 0, posX, posY, posZ, ori))
+        if (!creature->Create(map->GenerateLowGuid<HighGuid::Unit>(), map, GetGuildPhase(player), GetCreatureEntry(1), 0, posX, posY, posZ, ori))
         {
             handler->SendSysMessage("You already have the Guild House Butler!");
             handler->SetSentErrorMessage(true);

--- a/src/mod_guildhouse_butler.cpp
+++ b/src/mod_guildhouse_butler.cpp
@@ -13,6 +13,7 @@
 #include "GameObject.h"
 #include "Transport.h"
 #include "CreatureAI.h"
+#include "guildhouse.h"
 
 int cost, GuildHouseInnKeeper, GuildHouseBank, GuildHouseMailBox, GuildHouseAuctioneer, GuildHouseTrainer, GuildHouseVendor, GuildHouseObject, GuildHousePortal, GuildHouseSpirit, GuildHouseProf, GuildHouseBuyRank;
 
@@ -58,7 +59,7 @@ public:
         }
 
         ClearGossipMenuFor(player);
-        AddGossipItemFor(player, GOSSIP_ICON_TALK, "Spawn Innkeeper", GOSSIP_SENDER_MAIN, 500032, "Add an Innkeeper?", GuildHouseInnKeeper, false);
+        AddGossipItemFor(player, GOSSIP_ICON_TALK, "Spawn Innkeeper", GOSSIP_SENDER_MAIN, GetCreatureEntry(2), "Add an Innkeeper?", GuildHouseInnKeeper, false);
         AddGossipItemFor(player, GOSSIP_ICON_TALK, "Spawn Mailbox", GOSSIP_SENDER_MAIN, 184137, "Spawn a Mailbox?", GuildHouseMailBox, false);
         AddGossipItemFor(player, GOSSIP_ICON_TALK, "Spawn Stable Master", GOSSIP_SENDER_MAIN, 28690, "Spawn a Stable Master?", GuildHouseVendor, false);
         AddGossipItemFor(player, GOSSIP_ICON_TALK, "Spawn Class Trainer", GOSSIP_SENDER_MAIN, 2);
@@ -115,21 +116,21 @@ public:
             if (player->GetTeamId() == TEAM_ALLIANCE)
             {
                 // ALLIANCE players get these options
-                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Ironforge", GOSSIP_SENDER_MAIN, 500003, "Add Ironforge Portal?", GuildHousePortal, false);
-                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Darnassus", GOSSIP_SENDER_MAIN, 500001, "Add Darnassus Portal?", GuildHousePortal, false);
-                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Exodar", GOSSIP_SENDER_MAIN, 500002, "Add Exodar Portal?", GuildHousePortal, false);
+                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Ironforge", GOSSIP_SENDER_MAIN, GetGameObjectEntry(3), "Add Ironforge Portal?", GuildHousePortal, false);
+                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Darnassus", GOSSIP_SENDER_MAIN, GetGameObjectEntry(1), "Add Darnassus Portal?", GuildHousePortal, false);
+                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Exodar", GOSSIP_SENDER_MAIN, GetGameObjectEntry(2), "Add Exodar Portal?", GuildHousePortal, false);
             }
             else
             {
                 // HORDE players get these options
-                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Undercity", GOSSIP_SENDER_MAIN, 500007, "Add Undercity Portal?", GuildHousePortal, false);
-                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Thunderbluff", GOSSIP_SENDER_MAIN, 500006, "Add Thunderbuff Portal?", GuildHousePortal, false);
-                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Silvermoon", GOSSIP_SENDER_MAIN, 500005, "Add Silvermoon Portal?", GuildHousePortal, false);
+                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Undercity", GOSSIP_SENDER_MAIN, GetGameObjectEntry(7), "Add Undercity Portal?", GuildHousePortal, false);
+                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Thunderbluff", GOSSIP_SENDER_MAIN, GetGameObjectEntry(6), "Add Thunderbuff Portal?", GuildHousePortal, false);
+                AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Silvermoon", GOSSIP_SENDER_MAIN, GetGameObjectEntry(5), "Add Silvermoon Portal?", GuildHousePortal, false);
             }
 
             // These two portals work for either Team
-            AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Shattrath", GOSSIP_SENDER_MAIN, 500008, "Add Shattrath Portal?", GuildHousePortal, false);
-            AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Dalaran", GOSSIP_SENDER_MAIN, 500009, "Add Dalaran Portal?", GuildHousePortal, false);
+            AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Shattrath", GOSSIP_SENDER_MAIN, GetGameObjectEntry(8), "Add Shattrath Portal?", GuildHousePortal, false);
+            AddGossipItemFor(player, GOSSIP_ICON_TAXI, "Portal: Dalaran", GOSSIP_SENDER_MAIN, GetGameObjectEntry(9), "Add Dalaran Portal?", GuildHousePortal, false);
 
             AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Go Back!", GOSSIP_SENDER_MAIN, 9);
             SendGossipMenuFor(player, DEFAULT_GOSSIP_MESSAGE, m_creature->GetGUID());
@@ -191,7 +192,7 @@ public:
             cost = GuildHouseBank;
             SpawnNPC(action, player);
             break;
-        case 500032: // Innkeeper
+        case GetCreatureEntry(2): // Innkeeper
             cost = GuildHouseInnKeeper;
             SpawnNPC(action, player);
             break;
@@ -256,14 +257,14 @@ public:
             cost = GuildHouseObject;
             SpawnObject(action, player);
             break;
-        case 500001: // Darnassus Portal
-        case 500002: // Exodar Portal
-        case 500003: // Ironforge Portal
-        case 500005: // Silvermoon Portal
-        case 500006: // Thunder Bluff Portal
-        case 500007: // Undercity Portal
-        case 500008: // Shattrath Portal
-        case 500009: // Dalaran Portal
+        case GetGameObjectEntry(1): // Darnassus Portal
+        case GetGameObjectEntry(2): // Exodar Portal
+        case GetGameObjectEntry(3): // Ironforge Portal
+        case GetGameObjectEntry(5): // Silvermoon Portal
+        case GetGameObjectEntry(6): // Thunder Bluff Portal
+        case GetGameObjectEntry(7): // Undercity Portal
+        case GetGameObjectEntry(8): // Shattrath Portal
+        case GetGameObjectEntry(9): // Dalaran Portal
             cost = GuildHousePortal;
             SpawnObject(action, player);
             break;


### PR DESCRIPTION
In case you need to edit the Entity/GameObject ID's it can now be done in just 4 places.
Instead of in two dozen